### PR TITLE
Add ability to get the cursor of sounds

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -68,7 +68,7 @@ int main( int argc, char* argv[] )
         {
         case State::NarratorPart1:
             narrator.play();
-            if ( totalTime > 11.5 )
+            if ( narrator.getCursorInSeconds() > 11.5 )
             {
                 totalTime = 0.0;
                 narrator.pause();

--- a/inc/Audio/Sound.hpp
+++ b/inc/Audio/Sound.hpp
@@ -69,6 +69,12 @@ public:
     /// </summary>
     /// <returns>The duration of the sound (in seconds).</returns>
     float getDurationInSeconds() const;
+    
+    /// <summary>
+    /// Get the current cursor position of the sound in seconds.
+    /// </summary>
+    /// <returns>The current cursor position of the sound (in seconds).</returns>
+    float getCursorInSeconds() const;
 
     /// <summary>
     /// Seek to a specific position in the sound.

--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -90,6 +90,11 @@ float Sound::getDurationInSeconds() const
     return impl->getDurationInSeconds();
 }
 
+float Sound::getCursorInSeconds() const
+{
+	return impl->getCursorInSeconds();
+}
+
 void Sound::seek( uint64_t milliseconds )
 {
     impl->seek( milliseconds );

--- a/src/SoundImpl.cpp
+++ b/src/SoundImpl.cpp
@@ -41,6 +41,13 @@ float SoundImpl::getDurationInSeconds() const
     return duration;
 }
 
+float SoundImpl::getCursorInSeconds() const
+{
+	float cursor = 0.0f;
+	ma_sound_get_cursor_in_seconds( &const_cast<SoundImpl*>( this )->sound, &cursor );
+	return cursor;
+}
+
 void SoundImpl::seek( uint64_t milliseconds )
 {
     ma_uint32 sampleRate;

--- a/src/SoundImpl.hpp
+++ b/src/SoundImpl.hpp
@@ -22,6 +22,8 @@ public:
     void stop();
 
     float getDurationInSeconds() const;
+    
+    float getCursorInSeconds() const;
 
     void seek( uint64_t milliseconds );
 


### PR DESCRIPTION
Added functionality to retrieve the playback time (timestamp) of a sound (namely "cursor"), enabling precise audio transitions without the need for extra timers on the user side. You can check the example/main.cpp for a proper use case.

I personally wanted to play a sound starting at the same timestamp that another sound was stopped at.