### PR TITLE
Changes to 

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -52,9 +52,40 @@ int main( int argc, char* argv[] )
     double                   totalTime = 0.0;
 
     State state = State::NarratorPart1;
+// an enhancement to setfade has been added, normally you cannot fade up a sound that has been created with soundvolume at 1.0, or used setVolume(x.x), 
+// you can fade down but need to allow it to play long enough to hear it.. not ideal.
 
     background.setLooping( true );
-    background.setVolume( 0.2f );
+
+
+// Toggle this to switch between the broken and fixed fade-in.
+#define BROKEN_FADE  // comment out this line to use the working three-arg fade
+
+#ifdef BROKEN_FADE
+    // The intuitive-but-broken path: two-arg setFade starts from the current
+    // volume, so a sound already at full has nowhere to climb — no fade-up.
+    background.setVolume( 1.0f );      // audible base, so a working fade WOULD be heard
+    background.setFade( 1.0f, 3000 );  // won't fade up (already at 1.0); will however fade down and can use fade up when done
+    std::cout << "Background starts at 1 and stays there. There's no fade in\n";
+#else
+    // The fix: three-arg setFade takes an explicit begin volume, so it ramps
+    // from 0 to full regardless of current volume. Result is scaled by the base
+    // volume (fade is volume x gain), so keep base at 1.0 for full range.
+    background.setVolume( 1.0f );            // audible base, so a working fade WOULD be heard
+    background.setFade( 0.0f, 1.0f, 3000 );  // fades up from silence to full, you can also go higher than 1.0f but risk clipping
+    std::cout << "Background has a base of 1.0 but fade range of 0 to 1.0 creates fade in.\n";
+#endif
+
+/*
+    A point to note: the 2-arg form WILL fade up if you set a low non-zero base with
+    setVolume (e.g. 0.01f) and a much larger endVolume in setFade (e.g. 1000.0f),
+    because the fade gain then has room to climb. But this relies on endVolume being
+    an unclamped multiplier, and the product (base x gain) easily exceeds 1.0 and
+    clips — e.g. 0.01 x 1000 = 10, ten times full scale. It breaks the intended
+    0..1 volume model. The three-arg form gives the same fade-up cleanly and in range.
+ 
+  */
+    
     background.play();
 
     std::cout << "Hello, and welcome to the Audio library.\n";
@@ -63,7 +94,7 @@ int main( int argc, char* argv[] )
     while ( state != State::Done )
     {
         steady_clock::time_point t1 = steady_clock::now();
-
+ 
         auto elapsedTime = duration<double>( t1 - t0 );
         t0               = t1;
 

--- a/inc/Audio/Sound.hpp
+++ b/inc/Audio/Sound.hpp
@@ -329,6 +329,25 @@ public:
     void setFade( float endVolume, uint64_t milliseconds );
 
     /// <summary>
+    /// Fade this sound from a starting volume to an ending volume over a period of time.
+    /// </summary>
+    /// <typeparam name="Rep">The representation of the duration.</typeparam>
+    /// <typeparam name="Period">The duration period.</typeparam>
+    /// <param name="beginVolume">The volume to start this fade from.</param>
+    /// <param name="endVolume">The volume to fade this sound to.</param>
+    /// <param name="duration">The time to get to the `endVolume`.</param>
+    template<class Rep, class Period = std::ratio<1>>
+    void setFade( float beginVolume, float endVolume, const std::chrono::duration<Rep, Period>& duration );
+
+    /// <summary>
+    /// Fade this sound from a starting volume to an ending volume over a number of milliseconds.
+    /// </summary>
+    /// <param name="beginVolume">The volume to start this fade from.</param>
+    /// <param name="endVolume">The volume to fade this sound to.</param>
+    /// <param name="milliseconds">The duration in milliseconds to fade to `endVolume`.</param>
+    void setFade( float beginVolume, float endVolume, uint64_t milliseconds );
+
+    /// <summary>
     /// Schedule this sound to start playing at a specific time.
     /// Note: The sound must be explicitly started using `play`.
     /// </summary>
@@ -418,6 +437,13 @@ template<class Rep, class Period>
 void Sound::setFade( float endVolume, const std::chrono::duration<Rep, Period>& duration )
 {
     setFade( endVolume, std::chrono::duration_cast<std::chrono::milliseconds>( duration ).count() );
+}
+
+template<class Rep, class Period>
+void Sound::setFade( float beginVolume, float endVolume, const std::chrono::duration<Rep, Period>& duration )
+{
+    setFade( beginVolume, endVolume,
+             std::chrono::duration_cast<std::chrono::milliseconds>( duration ).count() );
 }
 
 template<class Rep, class Period>

--- a/inc/Audio/Sound.hpp
+++ b/inc/Audio/Sound.hpp
@@ -27,7 +27,7 @@ public:
 
     enum class AttenuationModel
     {
-        None,         ///< No distance attenuation and no specialization.
+        NoAttenuation,         ///< No distance attenuation and no specialization.
         Inverse,      ///< Equivalent to OpenAL's AL_INVERSE_DISTANCE_CLAMPED.
         Linear,       ///< Linear attenuation. Equivalent to OpenAL's AL_LINEAR_DISTANCE_CLAMPED.
         Exponential,  ///< Exponential attenuation. Equivalent to OpenAL's AL_EXPONENT_DISTANCE_CLAMPED.

--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -276,6 +276,11 @@ void Sound::setFade( float endVolume, uint64_t milliseconds )
     impl->setFade( endVolume, milliseconds );
 }
 
+void Sound::setFade( float beginVolume, float endVolume, uint64_t milliseconds )
+{
+    impl->setFade( beginVolume, endVolume, milliseconds );
+}
+
 void Sound::setStartTime( uint64_t milliseconds )
 {
     impl->setStartTime( milliseconds );

--- a/src/SoundImpl.cpp
+++ b/src/SoundImpl.cpp
@@ -162,7 +162,7 @@ void SoundImpl::setAttenuationModel( Sound::AttenuationModel attenuation )
 {
     switch ( attenuation )
     {
-    case Sound::AttenuationModel::None:
+    case Sound::AttenuationModel::NoAttenuation:
         ma_sound_set_attenuation_model( &sound, ma_attenuation_model_none );
         break;
     case Sound::AttenuationModel::Inverse:
@@ -182,7 +182,7 @@ Sound::AttenuationModel SoundImpl::getAttenuationModel() const
     switch ( ma_sound_get_attenuation_model( &sound ) )
     {
     case ma_attenuation_model_none:
-        return Sound::AttenuationModel::None;
+        return Sound::AttenuationModel::NoAttenuation;
     case ma_attenuation_model_inverse:
         return Sound::AttenuationModel::Inverse;
     case ma_attenuation_model_linear:
@@ -191,7 +191,7 @@ Sound::AttenuationModel SoundImpl::getAttenuationModel() const
         return Sound::AttenuationModel::Exponential;
     }
 
-    return Sound::AttenuationModel::None;
+    return Sound::AttenuationModel::NoAttenuation;
 }
 
 void SoundImpl::setRollOff( float rollOff )

--- a/src/SoundImpl.cpp
+++ b/src/SoundImpl.cpp
@@ -259,6 +259,11 @@ void SoundImpl::setFade( float endVolume, uint64_t milliseconds )
     ma_sound_set_fade_in_milliseconds( &sound, -1.0f, endVolume, milliseconds );
 }
 
+void SoundImpl::setFade( float beginVolume, float endVolume, uint64_t milliseconds )
+{
+    ma_sound_set_fade_in_milliseconds( &sound, beginVolume, endVolume, milliseconds );
+}
+
 void SoundImpl::setStartTime( uint64_t milliseconds )
 {
     ma_sound_set_start_time_in_milliseconds( &sound, milliseconds );

--- a/src/SoundImpl.hpp
+++ b/src/SoundImpl.hpp
@@ -78,6 +78,7 @@ public:
     float getDopplerFactor() const;
 
     void setFade( float endVolume, uint64_t milliseconds );
+    void setFade( float beginVolume, float endVolume, uint64_t milliseconds ); // an added fade to correct issues with the current fade
 
     void setStartTime( uint64_t milliseconds );
     void setStopTime( uint64_t milliseconds );


### PR DESCRIPTION
Changes to label None in  enum class AttenuationModel
as label None clashes with label None defined in X.11 making it impossible to build on a linux system using X11.h

Issues with sound.setFade(xx,xx) meant it was not possible to fade in a loaded sound with default volume of 1.  I added a 3 argument setfade to allow a start and end fade range 
